### PR TITLE
Treating tab character's length as indent_size instead of 1, by Updating autowrap.py

### DIFF
--- a/autowrap.py
+++ b/autowrap.py
@@ -49,13 +49,15 @@ class AutoWrapListener(sublime_plugin.EventListener):
         sel = view.sel()
         pt = sel[0].end()
         content = view.substr(view.line(pt))
+        indent_size=view.settings().get('tab_size')
+        tabCount=content.count('\t')
         wrap_width = get_wrap_width(view)
 
-        if len(content) <= wrap_width:
+        if len(content)+tabCount*(indent_size-1) <= wrap_width:
             return None
 
         if view.settings().get('auto_wrap_beyond_only', False):
-            if view.rowcol(pt)[1] < wrap_width:
+            if view.rowcol(pt)[1]+tabCount*(indent_size-1) < wrap_width:
                 return None
 
         default = [r"\[", r"\(", r"\{", " ", r"\n"]
@@ -65,7 +67,7 @@ class AutoWrapListener(sublime_plugin.EventListener):
         break_chars = "|".join(view.settings().get('auto_wrap_break_patterns', default))
         results = re.finditer(break_chars, content)
         indices = [m.start(0) for m in results] + [len(content)]
-        index = next(x[0] for x in enumerate(indices) if x[1] > wrap_width)
+        index = next(x[0] for x in enumerate(indices) if x[1]+tabCount*(indent_size-1) > wrap_width)
 
         if view.settings().get("auto_wrap_break_long_word", True) and index > 0:
             return view.line(pt).begin() + indices[index-1]


### PR DESCRIPTION
The plugin was treating tab character as 1 character. But actually sublime treats tab character's length same as indent_size. So if tab character is used in a line, it was not wrapping at expected length according to sublime's status bar.

 **Before:**
![before](https://user-images.githubusercontent.com/26321479/37960966-d2418392-31d8-11e8-808f-2c5d1243ace3.gif)


**After:**
![after](https://user-images.githubusercontent.com/26321479/37960979-de145550-31d8-11e8-893e-8a05189b067f.gif)
